### PR TITLE
Added Swiftify to the new Converters category

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -50,6 +50,9 @@
 		"title": "Benchmark",
 		"id": "benchmark"
 	}, {
+		"title": "Converters",
+		"id": "converters"
+	}, {
 		"title": "Demo Apps",
 		"id": "demo-apps",
 		"description": "Check out apps on these projects:"
@@ -4365,6 +4368,12 @@
 	 "category": "benchmark",
 	 "description": "Command line utility to profile compilation time of Swift project.",
 	 "homepage": "https://github.com/giginet/xcprofiler"
+ 	}, {
+	 "title": "Swiftify",
+	 "category": "converters",
+	 "description": "Objective-C to Swift online code converter and Xcode extension.",
+	 "homepage": "https://objectivec2swift.com",
+	 "tags": ["extensions", "ios", "macos", "objective-c", "swift"]
  	}, {
 		"title": "LocalizationKit",
 		"category": "localization",


### PR DESCRIPTION
- **Project Name**: 
Swiftify
- **Project URL**:
https://objectivec2swift.com/
- **Project Description**:
Objective-C to Swift online code converter and Xcode extension.
- **Why it should be added to `awesome-swift`**:
Swiftify is the only available automated code converter from Objective-C to Swift 3.
It is actively maintained and constantly improved.
The project itself is not open source, but it has thousands of users.
This is the reason I don't have a GitHub link with a necessary amount of stars - please advise if this one can still be included.
I suggest to introduce a new "Converters" category rather than adding this into existing "Misc" category.

- [ ] At least 15 stars (GitHub project)
- [x] Support `Swift 3`
- [x] Updated **contents.json** instead of README
